### PR TITLE
fix retaining view controllers

### DIFF
--- a/FlowControllerDemo/FlowControllerDemo/AppDelegate.swift
+++ b/FlowControllerDemo/FlowControllerDemo/AppDelegate.swift
@@ -23,8 +23,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         navigationController.navigationBar.backItem?.backBarButtonItem?.title = "c"
         navigationController.navigationItem.backBarButtonItem?.title = "a"
         
-        let hotelSearchFlowController = HotelSelectionFlowController()
-        hotelSearchFlowController.start(on: navigationController)
+        let hotelSearchFlowController = HotelSelectionFlowController(on: navigationController)
+        hotelSearchFlowController.start()
         
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()

--- a/FlowControllerDemo/FlowControllerDemo/Flows/Booking flow/BookingFlowController.swift
+++ b/FlowControllerDemo/FlowControllerDemo/Flows/Booking flow/BookingFlowController.swift
@@ -8,51 +8,34 @@
 
 import UIKit
 
-class BookingFlowController {
+class BookingFlowController: FlowController {
     
-    private(set) weak var navigationController: UINavigationController?
-    private(set) var router: Router!
-    
-    private(set) weak var parentFlowController: PromotionFlowController?
-    
+    let flowMode: FlowMode
     private(set) var reservation: Reservation
     
     var onCompleteBooking: (()->Void)? //todo:- booking
     var onDismiss: (()->Void)?
     
-    deinit {
-        print("### deinit: \(self)")
+    enum FlowMode {
+        case booking(with: Hotel)
+        case promotion(with: Hotel)
     }
     
-    //todo:- flow enum
-    init(hotel: Hotel, selectPromotion: Bool = false) {
-        reservation = Reservation(hotel: hotel)
-        if selectPromotion {
-            reservation.promotion = hotel.promotion
+    init(on navigationController: UINavigationController, for flow: FlowMode) {
+        flowMode = flow
+        switch flow {
+        case .booking(let hotel), .promotion(let hotel):
+            reservation = Reservation(hotel: hotel)
+            if case .promotion = flow { reservation.promotion = hotel.promotion }
         }
+        super.init(on: navigationController)
     }
     
-    func start(with parentFlowController: PromotionFlowController) {
-        self.parentFlowController = parentFlowController
-        start(on: parentFlowController.navigationController!)
-    }
     
-    func start(on navigationController: UINavigationController) {
-        self.navigationController = navigationController
-        self.router = Router(on: navigationController)
-//        self.router.onDismiss = { [unowned self] in
-////            self.parentFlowController?.dismissChild()
-//            self.onDismiss?()
-//        }
-        self.router.onDismiss = onDismiss
+    override func start() {
         showDatePicker()
     }
     
-    func dismiss(animated: Bool = true) {
-        //todo:- dismiss its own child (chaining)
-        router.onDismiss = nil
-        router.dismiss(animated: animated)
-    }
     
     //MARK:- Controller showing handler
     

--- a/FlowControllerDemo/FlowControllerDemo/Flows/Booking flow/BookingFlowController.swift
+++ b/FlowControllerDemo/FlowControllerDemo/Flows/Booking flow/BookingFlowController.swift
@@ -36,7 +36,6 @@ class BookingFlowController: FlowController {
         showDatePicker()
     }
     
-    
     //MARK:- Controller showing handler
     
     func showDatePicker() {

--- a/FlowControllerDemo/FlowControllerDemo/Flows/Booking flow/BookingFlowController.swift
+++ b/FlowControllerDemo/FlowControllerDemo/Flows/Booking flow/BookingFlowController.swift
@@ -18,6 +18,7 @@ class BookingFlowController {
     private(set) var reservation: Reservation
     
     var onCompleteBooking: (()->Void)? //todo:- booking
+    var onDismiss: (()->Void)?
     
     deinit {
         print("### deinit: \(self)")
@@ -39,14 +40,18 @@ class BookingFlowController {
     func start(on navigationController: UINavigationController) {
         self.navigationController = navigationController
         self.router = Router(on: navigationController)
-        self.router.onDismiss = { [unowned self] in
-            self.parentFlowController?.dismissChild()
-        }
+//        self.router.onDismiss = { [unowned self] in
+////            self.parentFlowController?.dismissChild()
+//            self.onDismiss?()
+//        }
+        self.router.onDismiss = onDismiss
         showDatePicker()
     }
     
-    func dismiss() {
-        
+    func dismiss(animated: Bool = true) {
+        //todo:- dismiss its own child (chaining)
+        router.onDismiss = nil
+        router.dismiss(animated: animated)
     }
     
     //MARK:- Controller showing handler

--- a/FlowControllerDemo/FlowControllerDemo/Flows/Booking flow/BookingFlowController.swift
+++ b/FlowControllerDemo/FlowControllerDemo/Flows/Booking flow/BookingFlowController.swift
@@ -13,19 +13,43 @@ class BookingFlowController {
     private(set) weak var navigationController: UINavigationController?
     private(set) var router: Router!
     
+    private(set) weak var parentFlowController: PromotionFlowController?
+    
     private(set) var reservation: Reservation
     
     var onCompleteBooking: (()->Void)? //todo:- booking
     
-    init(hotel: Hotel) {
+    deinit {
+        print("### deinit: \(self)")
+    }
+    
+    //todo:- flow enum
+    init(hotel: Hotel, selectPromotion: Bool = false) {
         reservation = Reservation(hotel: hotel)
+        if selectPromotion {
+            reservation.promotion = hotel.promotion
+        }
+    }
+    
+    func start(with parentFlowController: PromotionFlowController) {
+        self.parentFlowController = parentFlowController
+        start(on: parentFlowController.navigationController!)
     }
     
     func start(on navigationController: UINavigationController) {
         self.navigationController = navigationController
         self.router = Router(on: navigationController)
+        self.router.onDismiss = { [unowned self] in
+            self.parentFlowController?.dismissChild()
+        }
         showDatePicker()
     }
+    
+    func dismiss() {
+        
+    }
+    
+    //MARK:- Controller showing handler
     
     func showDatePicker() {
         let controller: DatePickerViewController = DatePickerViewController.loadFromNib()
@@ -72,6 +96,7 @@ class BookingFlowController {
         controller.reservation = reservation
         controller.onCompleteBooking = {
             print("### complete: booking flow")
+            self.onCompleteBooking?()
         }
         router.push(controller)
     }

--- a/FlowControllerDemo/FlowControllerDemo/Flows/FlowController.swift
+++ b/FlowControllerDemo/FlowControllerDemo/Flows/FlowController.swift
@@ -8,30 +8,30 @@
 
 import UIKit
 
-class FlowController {
-    
-    private(set) var navigationController: UINavigationController
-    private(set) var childFlowController: FlowController?
-    
-    init(navigationController: UINavigationController) {
-        self.navigationController = navigationController
-    }
-    
-    func start() {
-        
-    }
-    
-    func start(withParentFlowController parentFlowController: FlowController) {
-        navigationController = parentFlowController.navigationController
-        
-    }
-    
-    func proceed(to nextFlow: FlowController) {
-        childFlowController = nextFlow
-        nextFlow.start(withParentFlowController: self)
-    }
-    
-}
+//class FlowController {
+//    
+//    private(set) var navigationController: UINavigationController
+//    private(set) var childFlowController: FlowController?
+//    
+//    init(navigationController: UINavigationController) {
+//        self.navigationController = navigationController
+//    }
+//    
+//    func start() {
+//        
+//    }
+//    
+//    func start(withParentFlowController parentFlowController: FlowController) {
+//        navigationController = parentFlowController.navigationController
+//        
+//    }
+//    
+//    func proceed(to nextFlow: FlowController) {
+//        childFlowController = nextFlow
+//        nextFlow.start(withParentFlowController: self)
+//    }
+//    
+//}
 
 protocol FlowControllable {
     
@@ -41,13 +41,13 @@ protocol FlowControllable {
     var parentFlowController: FlowControllable? { get }
     
     func start()
-    func dismissChild(animated: Bool)
+    func start(from parentControllable: FlowControllable)
     func dismiss(animated: Bool)
     func proceed(to nextFlowControllable: FlowControllable)
     
 }
 
-class TestFlowController: FlowControllable {
+class FlowController: FlowControllable {
     
     private(set) var childFlowController: FlowControllable?
     private(set) var parentFlowController: FlowControllable?
@@ -58,28 +58,24 @@ class TestFlowController: FlowControllable {
     }
     
     func start() {
-        
+        //customizable implementaion
     }
     
-    func dismissChild(animated: Bool = true) {
-        
+    func start(from parentControllable: FlowControllable) {
+        self.parentFlowController = parentControllable
+        start()
     }
-    
-    func dismiss(animated: Bool = true) {
-        
-    }
-    
-    func proceed(to nextFlowControllable: FlowControllable) {
-        
-    }
-    
-}
-
-extension FlowControllable {
     
     func dismiss(animated: Bool = true) {
         router.dismiss(animated: animated)
-        parentFlowController?.router.navigationController.delegate = router
+        if let parentRouter = parentFlowController?.router {
+            parentRouter.navigationController.delegate = parentRouter
+        }
     }
     
+    func proceed(to nextFlowControllable: FlowControllable) {
+        childFlowController = nextFlowControllable
+        nextFlowControllable.start(from: self)
+    }
+
 }

--- a/FlowControllerDemo/FlowControllerDemo/Flows/FlowController.swift
+++ b/FlowControllerDemo/FlowControllerDemo/Flows/FlowController.swift
@@ -32,3 +32,54 @@ class FlowController {
     }
     
 }
+
+protocol FlowControllable {
+    
+    var router: Router { get }
+    
+    var childFlowController: FlowControllable? { get }
+    var parentFlowController: FlowControllable? { get }
+    
+    func start()
+    func dismissChild(animated: Bool)
+    func dismiss(animated: Bool)
+    func proceed(to nextFlowControllable: FlowControllable)
+    
+}
+
+class TestFlowController: FlowControllable {
+    
+    private(set) var childFlowController: FlowControllable?
+    private(set) var parentFlowController: FlowControllable?
+    private(set) var router: Router
+    
+    init(on navigationController: UINavigationController) {
+        router = Router(on: navigationController)
+    }
+    
+    func start() {
+        
+    }
+    
+    func dismissChild(animated: Bool = true) {
+        
+    }
+    
+    func dismiss(animated: Bool = true) {
+        
+    }
+    
+    func proceed(to nextFlowControllable: FlowControllable) {
+        
+    }
+    
+}
+
+extension FlowControllable {
+    
+    func dismiss(animated: Bool = true) {
+        router.dismiss(animated: animated)
+        parentFlowController?.router.navigationController.delegate = router
+    }
+    
+}

--- a/FlowControllerDemo/FlowControllerDemo/Flows/FlowController.swift
+++ b/FlowControllerDemo/FlowControllerDemo/Flows/FlowController.swift
@@ -33,16 +33,18 @@ import UIKit
 //    
 //}
 
-protocol FlowControllable {
+
+protocol FlowControllable: class {
     
     var router: Router { get }
     
     var childFlowController: FlowControllable? { get }
-    var parentFlowController: FlowControllable? { get }
+    weak var parentFlowController: FlowControllable? { get }
     
     func start()
     func start(from parentControllable: FlowControllable)
     func dismiss(animated: Bool)
+    func dismissChild(animated: Bool)
     func proceed(to nextFlowControllable: FlowControllable)
     
 }
@@ -50,20 +52,35 @@ protocol FlowControllable {
 class FlowController: FlowControllable {
     
     private(set) var childFlowController: FlowControllable?
-    private(set) var parentFlowController: FlowControllable?
+    private(set) weak var parentFlowController: FlowControllable?
     private(set) var router: Router
+    
+    deinit {
+        print("### deinit: \(self)")
+    }
     
     init(on navigationController: UINavigationController) {
         router = Router(on: navigationController)
+        router.onDismiss = { [unowned self] in
+            if let parentFlowController = self.parentFlowController {
+                parentFlowController.dismissChild(animated: true)
+            }
+        }
     }
     
     func start() {
         //customizable implementaion
     }
     
+    //todo:- private?
     func start(from parentControllable: FlowControllable) {
         self.parentFlowController = parentControllable
         start()
+    }
+    
+    func dismissChild(animated: Bool = true) {
+        childFlowController?.dismiss(animated: animated)
+        childFlowController = nil
     }
     
     func dismiss(animated: Bool = true) {
@@ -77,5 +94,5 @@ class FlowController: FlowControllable {
         childFlowController = nextFlowControllable
         nextFlowControllable.start(from: self)
     }
-
+    
 }

--- a/FlowControllerDemo/FlowControllerDemo/Flows/Hotel selection flow/HotelSelectionFlowController.swift
+++ b/FlowControllerDemo/FlowControllerDemo/Flows/Hotel selection flow/HotelSelectionFlowController.swift
@@ -8,18 +8,11 @@
 
 import UIKit
 
-class HotelSelectionFlowController {
-    
-    private(set) weak var navigationController: UINavigationController?
-    private(set) weak var parentFlowController: FlowController?
-    private(set) var childFlowController: FlowController?
-    private(set) var router: Router!
+class HotelSelectionFlowController: FlowController {
     
     var onSelectHotel: ((_ hotel: Hotel)->Void)?
     
-    func start(on navigationController: UINavigationController) {
-        self.navigationController = navigationController
-        self.router = Router(on: navigationController)
+    override func start() {
         showHotelSearch()
     }
     
@@ -29,8 +22,7 @@ class HotelSelectionFlowController {
         controller.onSelectPickCountry = {
             self.showCountryPicker()
         }
-        
-        navigationController?.pushViewController(controller, animated: true)
+        router.push(controller)
     }
     
     func showCountryPicker() {
@@ -39,8 +31,7 @@ class HotelSelectionFlowController {
         controller.onSelectCountry = { country in
             self.showHotelPicker(for: country)
         }
-        
-        navigationController?.pushViewController(controller, animated: true)
+        router.push(controller)
     }
     
     func showHotelPicker(for country: Country) {
@@ -49,11 +40,10 @@ class HotelSelectionFlowController {
         controller.onSelectHotel = { hotel in
 //            let bookingFlowController = BookingFlowController(hotel: hotel)
 //            bookingFlowController.start(on: self.navigationController!)
-            let promotionFlowController = PromotionFlowController()
-            promotionFlowController.start(on: self.navigationController!)
+            let promotionFlowController = PromotionFlowController(on: self.router.navigationController)
+            promotionFlowController.start()
         }
-        
-        navigationController?.pushViewController(controller, animated: true)
+        router.push(controller)
     }
     
     

--- a/FlowControllerDemo/FlowControllerDemo/Flows/Hotel selection flow/HotelSelectionFlowController.swift
+++ b/FlowControllerDemo/FlowControllerDemo/Flows/Hotel selection flow/HotelSelectionFlowController.swift
@@ -41,7 +41,7 @@ class HotelSelectionFlowController: FlowController {
 //            let bookingFlowController = BookingFlowController(hotel: hotel)
 //            bookingFlowController.start(on: self.navigationController!)
             let promotionFlowController = PromotionFlowController(on: self.router.navigationController)
-            promotionFlowController.start()
+            self.proceed(to: promotionFlowController)
         }
         router.push(controller)
     }

--- a/FlowControllerDemo/FlowControllerDemo/Flows/Promotion flow/PromotionFlowController.swift
+++ b/FlowControllerDemo/FlowControllerDemo/Flows/Promotion flow/PromotionFlowController.swift
@@ -29,17 +29,21 @@ class PromotionFlowController: FlowController  {
         let controller: PromotionDetailViewController = PromotionDetailViewController.loadFromNib()
         controller.hotel = hotel
         controller.onSelectBookNow = { hotel in
-            let bookingFlowController = BookingFlowController(on: self.router.navigationController,
-                                                              for: .promotion(with: hotel))
-            bookingFlowController.onCompleteBooking = {
-                self.dismissChild()
-            }
-            bookingFlowController.onDismiss = {
-                self.dismissChild()
-            }
-            self.proceed(to: bookingFlowController)
+            self.proceedToBookingFlow(for: hotel)
         }
         router.push(controller)
+    }
+    
+    func proceedToBookingFlow(for hotel: Hotel) {
+        let bookingFlowController = BookingFlowController(on: self.router.navigationController,
+                                                          for: .promotion(with: hotel))
+        bookingFlowController.onCompleteBooking = { [unowned self] in
+            self.dismissChild()
+        }
+        bookingFlowController.onDismiss = { [unowned self] in
+            self.dismissChild()
+        }
+        self.proceed(to: bookingFlowController)
     }
     
 }

--- a/FlowControllerDemo/FlowControllerDemo/Flows/Promotion flow/PromotionFlowController.swift
+++ b/FlowControllerDemo/FlowControllerDemo/Flows/Promotion flow/PromotionFlowController.swift
@@ -27,6 +27,7 @@ class PromotionFlowController {
     
     func dismissChild() {
         //todo:- iterate to dismiss all flowController of its child
+        childFlowController?.dismiss(animated: true)
         childFlowController = nil
         router.navigationController.delegate = router
     }
@@ -48,6 +49,10 @@ class PromotionFlowController {
             bookingFlowController.onCompleteBooking = {
                 self.dismissChild()
             }
+            bookingFlowController.onDismiss = {
+                self.dismissChild()
+            }
+            self.childFlowController = bookingFlowController
             bookingFlowController.start(with: self)
         }
         router.push(controller)

--- a/FlowControllerDemo/FlowControllerDemo/Flows/Promotion flow/PromotionFlowController.swift
+++ b/FlowControllerDemo/FlowControllerDemo/Flows/Promotion flow/PromotionFlowController.swift
@@ -28,6 +28,7 @@ class PromotionFlowController {
     func dismissChild() {
         //todo:- iterate to dismiss all flowController of its child
         childFlowController = nil
+        router.navigationController.delegate = router
     }
     
     func showPromotions() {

--- a/FlowControllerDemo/FlowControllerDemo/Flows/Promotion flow/PromotionFlowController.swift
+++ b/FlowControllerDemo/FlowControllerDemo/Flows/Promotion flow/PromotionFlowController.swift
@@ -12,6 +12,8 @@ class PromotionFlowController {
     
     private(set) weak var navigationController: UINavigationController?
     private(set) var router: Router!
+    
+    private(set) var childFlowController: BookingFlowController?
 
     var onSelectBookingWithPromotion: ((Promotion)->Void)?
     
@@ -21,6 +23,11 @@ class PromotionFlowController {
         self.navigationController = navigationController
         self.router = Router(on: navigationController)
         showPromotions()
+    }
+    
+    func dismissChild() {
+        //todo:- iterate to dismiss all flowController of its child
+        childFlowController = nil
     }
     
     func showPromotions() {
@@ -38,9 +45,9 @@ class PromotionFlowController {
         controller.onSelectBookNow = { hotel in
             let bookingFlowController = BookingFlowController(hotel: hotel, selectPromotion: true)
             bookingFlowController.onCompleteBooking = {
-                self.router.setViewControllers([])
+                self.dismissChild()
             }
-            bookingFlowController.start(on: self.navigationController!)
+            bookingFlowController.start(with: self)
         }
         router.push(controller)
     }

--- a/FlowControllerDemo/FlowControllerDemo/Flows/Promotion flow/PromotionFlowController.swift
+++ b/FlowControllerDemo/FlowControllerDemo/Flows/Promotion flow/PromotionFlowController.swift
@@ -8,28 +8,12 @@
 
 import UIKit
 
-class PromotionFlowController {
-    
-    private(set) weak var navigationController: UINavigationController?
-    private(set) var router: Router!
-    
-    private(set) var childFlowController: BookingFlowController?
+class PromotionFlowController: FlowController  {
 
     var onSelectBookingWithPromotion: ((Promotion)->Void)?
     
-    //todo:- start with option?
-    
-    func start(on navigationController: UINavigationController) {
-        self.navigationController = navigationController
-        self.router = Router(on: navigationController)
+    override func start() {
         showPromotions()
-    }
-    
-    func dismissChild() {
-        //todo:- iterate to dismiss all flowController of its child
-        childFlowController?.dismiss(animated: true)
-        childFlowController = nil
-        router.navigationController.delegate = router
     }
     
     func showPromotions() {
@@ -45,15 +29,15 @@ class PromotionFlowController {
         let controller: PromotionDetailViewController = PromotionDetailViewController.loadFromNib()
         controller.hotel = hotel
         controller.onSelectBookNow = { hotel in
-            let bookingFlowController = BookingFlowController(hotel: hotel, selectPromotion: true)
+            let bookingFlowController = BookingFlowController(on: self.router.navigationController,
+                                                              for: .promotion(with: hotel))
             bookingFlowController.onCompleteBooking = {
                 self.dismissChild()
             }
             bookingFlowController.onDismiss = {
                 self.dismissChild()
             }
-            self.childFlowController = bookingFlowController
-            bookingFlowController.start(with: self)
+            self.proceed(to: bookingFlowController)
         }
         router.push(controller)
     }

--- a/FlowControllerDemo/FlowControllerDemo/Routers/Router.swift
+++ b/FlowControllerDemo/FlowControllerDemo/Routers/Router.swift
@@ -54,7 +54,7 @@ class Router: NSObject {
         } else {
             setViewControllers([], animated: animated)
         }
-        onDismiss?()
+//        onDismiss?()
     }
     
     //todo:- test needed!

--- a/FlowControllerDemo/FlowControllerDemo/Routers/Router.swift
+++ b/FlowControllerDemo/FlowControllerDemo/Routers/Router.swift
@@ -8,12 +8,13 @@
 
 import UIKit
 
-class Router {
+class Router: NSObject {
     
     let navigationController: UINavigationController
     
-    private(set) var viewControllers = [UIViewController]()
+    fileprivate(set) var viewControllers = [UIViewController]()
     
+    //todo:- delegate and make base flow controller listen to this instead?
     var onDismiss: (()->Void)?
     
     var rootViewController: UIViewController? {
@@ -22,24 +23,22 @@ class Router {
     
     init(on navigationController: UINavigationController) {
         self.navigationController = navigationController
+        super.init()
+        self.navigationController.delegate = self
     }
     
     //todo:- push(_ pushable: Pushable) instead?
     
     func push(_ viewController: UIViewController, animated: Bool = true) {
         assert(!viewControllers.contains(viewController), "pushing the same view controller twice is not allowed")
-        
-        //todo:- check for other cases when deinited
-        // when popped, remove the view controller itself from the stack
-        viewController.onDeinit = { [weak self] in
-            self?.viewControllers.removeLast()
-        }
         navigationController.pushViewController(viewController, animated: animated)
         viewControllers.append(viewController)
     }
     
+    //todo:- test needed!
+    
     func pop(animated: Bool = true) -> UIViewController? {
-        viewControllers.removeLast()
+//        viewControllers.removeLast()
         return navigationController.popViewController(animated: animated)
     }
     
@@ -55,6 +54,7 @@ class Router {
         } else {
             setViewControllers([], animated: animated)
         }
+        onDismiss?()
     }
     
     //todo:- test needed!
@@ -66,6 +66,30 @@ class Router {
             let lastIndex = currentViewControllers.index(of: self.viewControllers.last!) else { return }
         currentViewControllers.replaceSubrange(firstIndex...lastIndex, with: viewControllers)
         navigationController.setViewControllers(currentViewControllers, animated: animated)
+        self.viewControllers = viewControllers
+    }
+    
+}
+
+extension Router: UINavigationControllerDelegate {
+    
+    func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+        guard let fromViewController = navigationController.transitionCoordinator?.viewController(forKey: .from),
+            !navigationController.viewControllers.contains(fromViewController) else { return }
+        cleanUp()
+        if viewControllers.count == 0 {
+            onDismiss?()
+        }
+    }
+    
+    private func cleanUp() {
+        while (viewControllers.count > 0) && !isTopViewControllerInSync {
+            viewControllers.removeLast()
+        }
+    }
+    
+    private var isTopViewControllerInSync: Bool {
+        return navigationController.viewControllers.last == viewControllers.last
     }
     
 }


### PR DESCRIPTION
fixed an issue for a retain cycle that happened when dismissing `FlowController` (both by native back button and dismiss function). also made a protocol `FlowControllable` and base `FlowController` class, which could be improved later

**problem:**
- the first problem was caused by `viewControllers` in `Router` were retained and ARC couldn't dealloc it even though it was popped out of the `navigationController` as `Router` was still holding the popped `viewController`.
- the second problem was `flowController` not getting dealloc by ARC when it was supposed to be dismissed (even all the `viewController`s inside were already deallocated). found out that the root cause of this problem was a closure `onDismiss` (which is supposed to be renamed as it's not expressive enough) retained `self` (so a simple `[unowned self]` solved this)

**note:**
- there's another way to implement this. Instead of using `viewControllers`, we just let it be only a computed property and store `rootViewController` and `viewControllersCount`. This would help clearing a retain cycle, as we don't have to hold any `viewController` any more (except for the weak `rootViewController`), and make way for `deinitObservable` to come into the play.
- still need to do some research on which implemention is better.